### PR TITLE
improvements and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ No more will I suffer.
 
 `php artisan calebporzio:helpers`
 
-This command will create a `app/helpers.php` file in your project and handle the autolaoding for you automatically.
+This command will create a `app/helpers.php` file in your project and handle the autoloading for you automatically.
 
 Hope this silly lil' package comes in handy for you.

--- a/src/InstallCommand.php
+++ b/src/InstallCommand.php
@@ -8,26 +8,31 @@ use Illuminate\Support\Facades\File;
 class InstallCommand extends Command
 {
     protected $signature = 'calebporzio:helpers';
+    protected $description = 'Add a app/helpers.php file to your project';
 
     public function handle()
     {
-        $app = $this->getApplication()->getLaravel();
+        $helpersFilePath = app_path('helpers.php');
 
-        $helpersFilePath = $app->make('path') . DIRECTORY_SEPARATOR . 'helpers.php';
-
-        $files = $app->make('files');
-
-        if ($files->exists($helpersFilePath)) {
+        if (File::exists($helpersFilePath)) {
             $this->info('Looks like you\'ve already created a helpers file');
             return;
         }
 
-        $helpersFileContents = <<<EOT
+        File::put($helpersFilePath, $this->helpersFileContents());
+        $this->info('Hooray! Your app/helpers.php file awaits you...');
+    }
+
+    protected function helpersFileContents()
+    {
+        return <<<EOT
 <?php
 
 /**
  *  Custom Laravel Helpers
  */
+
+use Illuminate\Support\Carbon;
 
 if (! function_exists('carbon')) {
     function carbon(\$parseString = null, \$tz = null)
@@ -37,9 +42,5 @@ if (! function_exists('carbon')) {
 }
 
 EOT;
-
-        $files->put($helpersFilePath, $helpersFileContents);
-
-        $this->info('Hooray! Your app/helpers.php file awaits you...');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,19 +2,21 @@
 
 namespace CalebPorzio\LaravelHelpersFile;
 
-use CalebPorzio\AddLaravelHelpersFile;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
 {
     public function boot()
     {
-        $this->commands([
-            InstallCommand::class
-        ]);
+    	if ($this->app->runningInConsole()) {
+	        $this->commands([
+	            InstallCommand::class
+	        ]);
+    	}
 
-        $helpersFilePath = $this->app->make('path') . DIRECTORY_SEPARATOR . 'helpers.php';
-
-        require_once($helpersFilePath);
+        if (File::exists(app_path('helpers.php'))) {
+        	require_once app_path('helpers.php');
+        }
     }
 }


### PR DESCRIPTION
When trying to install this package via composer, PHP fails.

Please take a look at the image below for further details:

![composer](https://user-images.githubusercontent.com/834048/48324293-4ae5a380-e617-11e8-94a3-ce9e561d1820.png)

This PR fixes this bug and adds some small improvements:

- remove unnecessary use statements;
- add a description message to calebporzio:helpers command
- use File Facade
- use app_path() in order to reference app/helpers.php file
- extract contents for app/helpers.php template to its own method
- fix app/helpers.php template code by including Carbon’s use statement
- fix ServiceProvider so that app/helpers.php is included only if it really exists
- fix README typo